### PR TITLE
Add step stopped state coming from a gitlab canceled job

### DIFF
--- a/backend/parser/gitlab/build.ts
+++ b/backend/parser/gitlab/build.ts
@@ -144,6 +144,10 @@ class GitLabBuildParser {
 			return 'running';
 		}
 
+		if (steps.find((step) => ['stopped'].includes(step.state))) {
+			return 'stopped';
+		}
+
 		if (steps.find((step) => ['created', 'pending'].includes(step.state))) {
 			return 'pending';
 		}

--- a/backend/parser/gitlab/helper.ts
+++ b/backend/parser/gitlab/helper.ts
@@ -1,27 +1,33 @@
+import { GitLabStatus } from 'types/gitlab';
 import { State, StepState } from 'types/status';
 
-export const statusToState = (status: string): State => {
-	const gitlabStatuses = {
+type GitLabStatusMapper<ExpectedState> = {
+	// eslint-disable-next-line no-unused-vars
+	[K in GitLabStatus]: ExpectedState;
+};
+
+export const statusToState = (status: GitLabStatus): State => {
+	const states: GitLabStatusMapper<State> = {
 		pending: 'warning',
 		running: 'warning',
+		created: 'info',
+		canceled: 'info',
 		failed: 'error',
 		success: 'success',
 	};
 
-	return gitlabStatuses[status] || 'info';
+	return states[status] || 'info';
 };
 
-export const statusToStepState = (status: string, allowFailure: boolean): StepState => {
-	switch (status) {
-		case 'failed':
-			return allowFailure ? 'soft-failed' : 'failed';
-		case 'success':
-			return 'success';
-		case 'running':
-			return 'running';
-		case 'pending':
-			return 'pending';
-		default:
-			return 'created';
-	}
+export const statusToStepState = (status: GitLabStatus, allowFailure: boolean): StepState => {
+	const states: GitLabStatusMapper<StepState> = {
+		pending: 'pending',
+		running: 'running',
+		created: 'created',
+		canceled: 'stopped',
+		failed: allowFailure ? 'soft-failed' : 'failed',
+		success: 'success',
+	};
+
+	return states[status] || 'created';
 };

--- a/cypress/fixtures/gitlab/canceled-pipeline/1.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/1.json
@@ -1,0 +1,60 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231241,
+		"build_name": "frontend ci",
+		"build_stage": "builder",
+		"build_status": "created",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": null,
+		"build_finished_at": null,
+		"build_duration": null,
+		"build_queued_duration": null,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": null,
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "created",
+			"duration": null,
+			"started_at": null,
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/10.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/10.json
@@ -1,0 +1,271 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Pipeline Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "pipeline",
+		"object_attributes": {
+			"id": 692601837,
+			"iid": 954,
+			"ref": "production",
+			"tag": false,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"before_sha": "0000000000000000000000000000000000000000",
+			"source": "web",
+			"status": "running",
+			"detailed_status": "running",
+			"stages": ["builder", "cache", "test", "build", "deploy", "merge back"],
+			"created_at": "2022-11-11 20:01:51 UTC",
+			"finished_at": null,
+			"duration": null,
+			"queued_duration": 1,
+			"variables": []
+		},
+		"merge_request": null,
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"project": {
+			"id": 763808,
+			"name": "RickvanderStaaij",
+			"description": "https://rick.nu source code",
+			"web_url": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/763808/avatar-blue.png",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"namespace": "FuturePortal",
+			"visibility_level": 20,
+			"path_with_namespace": "FuturePortal/RickvanderStaaij",
+			"default_branch": "production",
+			"ci_config_path": null
+		},
+		"commit": {
+			"id": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"title": "Downgrade to node 16 for the current production state",
+			"timestamp": "2022-11-11T19:05:51+01:00",
+			"url": "https://gitlab.com/FuturePortal/RickvanderStaaij/-/commit/2c55f17d517d720c120cfc0e76873454ada29b52",
+			"author": {
+				"name": "Rick van der Staaij",
+				"email": "[REDACTED]"
+			}
+		},
+		"builds": [
+			{
+				"id": 3312231243,
+				"stage": "cache",
+				"name": "frontend cache",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231245,
+				"stage": "test",
+				"name": "codestyle",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231247,
+				"stage": "test",
+				"name": "typescript",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231250,
+				"stage": "build",
+				"name": "frontend image",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231254,
+				"stage": "deploy",
+				"name": "deploy to production",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:52 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": {
+					"name": "production",
+					"action": "start",
+					"deployment_tier": "production"
+				}
+			},
+			{
+				"id": 3312231255,
+				"stage": "merge back",
+				"name": "update branches",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:52 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231241,
+				"stage": "builder",
+				"name": "frontend ci",
+				"status": "running",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": "2022-11-11 20:01:53 UTC",
+				"finished_at": null,
+				"duration": 0.442969078,
+				"queued_duration": 0.958811,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": {
+					"id": 15232634,
+					"description": "xps-9720.rick.nu",
+					"runner_type": "group_type",
+					"active": true,
+					"is_shared": false,
+					"tags": []
+				},
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			}
+		]
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/11.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/11.json
@@ -1,0 +1,67 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231241,
+		"build_name": "frontend ci",
+		"build_stage": "builder",
+		"build_status": "running",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": "2022-11-11 20:01:53 UTC",
+		"build_finished_at": null,
+		"build_duration": 0.112236577,
+		"build_queued_duration": 0.958811106,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": {
+			"id": 15232634,
+			"description": "xps-9720.rick.nu",
+			"runner_type": "group_type",
+			"active": true,
+			"is_shared": false,
+			"tags": []
+		},
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "pending",
+			"duration": null,
+			"started_at": null,
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/12.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/12.json
@@ -1,0 +1,60 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231245,
+		"build_name": "codestyle",
+		"build_stage": "test",
+		"build_status": "canceled",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": null,
+		"build_finished_at": "2022-11-11 20:02:00 UTC",
+		"build_duration": null,
+		"build_queued_duration": null,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": null,
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "running",
+			"duration": null,
+			"started_at": "2022-11-11 20:01:53 UTC",
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/13.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/13.json
@@ -1,0 +1,67 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231241,
+		"build_name": "frontend ci",
+		"build_stage": "builder",
+		"build_status": "success",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": "2022-11-11 20:01:53 UTC",
+		"build_finished_at": "2022-11-11 20:02:38 UTC",
+		"build_duration": 45.363471,
+		"build_queued_duration": 0.958811,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": {
+			"id": 15232634,
+			"description": "xps-9720.rick.nu",
+			"runner_type": "group_type",
+			"active": true,
+			"is_shared": false,
+			"tags": []
+		},
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "running",
+			"duration": null,
+			"started_at": "2022-11-11 20:01:53 UTC",
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/14.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/14.json
@@ -1,0 +1,60 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231243,
+		"build_name": "frontend cache",
+		"build_stage": "cache",
+		"build_status": "pending",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": null,
+		"build_finished_at": null,
+		"build_duration": null,
+		"build_queued_duration": 0.077434032,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": null,
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "running",
+			"duration": null,
+			"started_at": "2022-11-11 20:01:53 UTC",
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/15.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/15.json
@@ -1,0 +1,67 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231243,
+		"build_name": "frontend cache",
+		"build_stage": "cache",
+		"build_status": "running",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": "2022-11-11 20:02:41 UTC",
+		"build_finished_at": null,
+		"build_duration": 0.090238162,
+		"build_queued_duration": 2.5142019,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": {
+			"id": 15232634,
+			"description": "xps-9720.rick.nu",
+			"runner_type": "group_type",
+			"active": true,
+			"is_shared": false,
+			"tags": []
+		},
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "running",
+			"duration": null,
+			"started_at": "2022-11-11 20:01:53 UTC",
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/16.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/16.json
@@ -1,0 +1,67 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231243,
+		"build_name": "frontend cache",
+		"build_stage": "cache",
+		"build_status": "success",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": "2022-11-11 20:02:41 UTC",
+		"build_finished_at": "2022-11-11 20:03:34 UTC",
+		"build_duration": 53.11956,
+		"build_queued_duration": 2.514201,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": {
+			"id": 15232634,
+			"description": "xps-9720.rick.nu",
+			"runner_type": "group_type",
+			"active": true,
+			"is_shared": false,
+			"tags": []
+		},
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "running",
+			"duration": null,
+			"started_at": "2022-11-11 20:01:53 UTC",
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/17.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/17.json
@@ -1,0 +1,60 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231247,
+		"build_name": "typescript",
+		"build_stage": "test",
+		"build_status": "pending",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": null,
+		"build_finished_at": null,
+		"build_duration": null,
+		"build_queued_duration": 0.084122953,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": null,
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "running",
+			"duration": null,
+			"started_at": "2022-11-11 20:01:53 UTC",
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/18.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/18.json
@@ -1,0 +1,67 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231247,
+		"build_name": "typescript",
+		"build_stage": "test",
+		"build_status": "running",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": "2022-11-11 20:03:35 UTC",
+		"build_finished_at": null,
+		"build_duration": 0.087957552,
+		"build_queued_duration": 0.797884125,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": {
+			"id": 15232634,
+			"description": "xps-9720.rick.nu",
+			"runner_type": "group_type",
+			"active": true,
+			"is_shared": false,
+			"tags": []
+		},
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "running",
+			"duration": null,
+			"started_at": "2022-11-11 20:01:53 UTC",
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/19.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/19.json
@@ -1,0 +1,285 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Pipeline Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "pipeline",
+		"object_attributes": {
+			"id": 692601837,
+			"iid": 954,
+			"ref": "production",
+			"tag": false,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"before_sha": "0000000000000000000000000000000000000000",
+			"source": "web",
+			"status": "canceled",
+			"detailed_status": "canceled",
+			"stages": ["builder", "cache", "test", "build", "deploy", "merge back"],
+			"created_at": "2022-11-11 20:01:51 UTC",
+			"finished_at": "2022-11-11 20:04:28 UTC",
+			"duration": 150,
+			"queued_duration": 1,
+			"variables": []
+		},
+		"merge_request": null,
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"project": {
+			"id": 763808,
+			"name": "RickvanderStaaij",
+			"description": "https://rick.nu source code",
+			"web_url": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/763808/avatar-blue.png",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"namespace": "FuturePortal",
+			"visibility_level": 20,
+			"path_with_namespace": "FuturePortal/RickvanderStaaij",
+			"default_branch": "production",
+			"ci_config_path": null
+		},
+		"commit": {
+			"id": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"title": "Downgrade to node 16 for the current production state",
+			"timestamp": "2022-11-11T19:05:51+01:00",
+			"url": "https://gitlab.com/FuturePortal/RickvanderStaaij/-/commit/2c55f17d517d720c120cfc0e76873454ada29b52",
+			"author": {
+				"name": "Rick van der Staaij",
+				"email": "[REDACTED]"
+			}
+		},
+		"builds": [
+			{
+				"id": 3312231245,
+				"stage": "test",
+				"name": "codestyle",
+				"status": "canceled",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": null,
+				"finished_at": "2022-11-11 20:02:00 UTC",
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231247,
+				"stage": "test",
+				"name": "typescript",
+				"status": "success",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": "2022-11-11 20:03:35 UTC",
+				"finished_at": "2022-11-11 20:04:27 UTC",
+				"duration": 52.430035,
+				"queued_duration": 0.797884,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": {
+					"id": 15232634,
+					"description": "xps-9720.rick.nu",
+					"runner_type": "group_type",
+					"active": true,
+					"is_shared": false,
+					"tags": []
+				},
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231250,
+				"stage": "build",
+				"name": "frontend image",
+				"status": "skipped",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231241,
+				"stage": "builder",
+				"name": "frontend ci",
+				"status": "success",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": "2022-11-11 20:01:53 UTC",
+				"finished_at": "2022-11-11 20:02:38 UTC",
+				"duration": 45.363471,
+				"queued_duration": 0.958811,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": {
+					"id": 15232634,
+					"description": "xps-9720.rick.nu",
+					"runner_type": "group_type",
+					"active": true,
+					"is_shared": false,
+					"tags": []
+				},
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231243,
+				"stage": "cache",
+				"name": "frontend cache",
+				"status": "success",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": "2022-11-11 20:02:41 UTC",
+				"finished_at": "2022-11-11 20:03:34 UTC",
+				"duration": 53.11956,
+				"queued_duration": 2.514201,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": {
+					"id": 15232634,
+					"description": "xps-9720.rick.nu",
+					"runner_type": "group_type",
+					"active": true,
+					"is_shared": false,
+					"tags": []
+				},
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231254,
+				"stage": "deploy",
+				"name": "deploy to production",
+				"status": "skipped",
+				"created_at": "2022-11-11 20:01:52 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": {
+					"name": "production",
+					"action": "start",
+					"deployment_tier": "production"
+				}
+			},
+			{
+				"id": 3312231255,
+				"stage": "merge back",
+				"name": "update branches",
+				"status": "skipped",
+				"created_at": "2022-11-11 20:01:52 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			}
+		]
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/2.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/2.json
@@ -1,0 +1,60 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231243,
+		"build_name": "frontend cache",
+		"build_stage": "cache",
+		"build_status": "created",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": null,
+		"build_finished_at": null,
+		"build_duration": null,
+		"build_queued_duration": null,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": null,
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "created",
+			"duration": null,
+			"started_at": null,
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/20.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/20.json
@@ -1,0 +1,67 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231247,
+		"build_name": "typescript",
+		"build_stage": "test",
+		"build_status": "success",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": "2022-11-11 20:03:35 UTC",
+		"build_finished_at": "2022-11-11 20:04:27 UTC",
+		"build_duration": 52.430035,
+		"build_queued_duration": 0.797884,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": {
+			"id": 15232634,
+			"description": "xps-9720.rick.nu",
+			"runner_type": "group_type",
+			"active": true,
+			"is_shared": false,
+			"tags": []
+		},
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "running",
+			"duration": null,
+			"started_at": "2022-11-11 20:01:53 UTC",
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/3.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/3.json
@@ -1,0 +1,60 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231247,
+		"build_name": "typescript",
+		"build_stage": "test",
+		"build_status": "created",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": null,
+		"build_finished_at": null,
+		"build_duration": null,
+		"build_queued_duration": null,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": null,
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "created",
+			"duration": null,
+			"started_at": null,
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/4.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/4.json
@@ -1,0 +1,60 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231250,
+		"build_name": "frontend image",
+		"build_stage": "build",
+		"build_status": "created",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": null,
+		"build_finished_at": null,
+		"build_duration": null,
+		"build_queued_duration": null,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": null,
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "created",
+			"duration": null,
+			"started_at": null,
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/5.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/5.json
@@ -1,0 +1,63 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231254,
+		"build_name": "deploy to production",
+		"build_stage": "deploy",
+		"build_status": "created",
+		"build_created_at": "2022-11-11 20:01:52 UTC",
+		"build_started_at": null,
+		"build_finished_at": null,
+		"build_duration": null,
+		"build_queued_duration": null,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": null,
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "created",
+			"duration": null,
+			"started_at": null,
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": {
+			"name": "production",
+			"action": "start"
+		}
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/6.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/6.json
@@ -1,0 +1,60 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231245,
+		"build_name": "codestyle",
+		"build_stage": "test",
+		"build_status": "created",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": null,
+		"build_finished_at": null,
+		"build_duration": null,
+		"build_queued_duration": null,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": null,
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "created",
+			"duration": null,
+			"started_at": null,
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/7.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/7.json
@@ -1,0 +1,60 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231255,
+		"build_name": "update branches",
+		"build_stage": "merge back",
+		"build_status": "created",
+		"build_created_at": "2022-11-11 20:01:52 UTC",
+		"build_started_at": null,
+		"build_finished_at": null,
+		"build_duration": null,
+		"build_queued_duration": null,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": null,
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "created",
+			"duration": null,
+			"started_at": null,
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/8.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/8.json
@@ -1,0 +1,60 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Job Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "production",
+		"tag": false,
+		"before_sha": "0000000000000000000000000000000000000000",
+		"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+		"build_id": 3312231241,
+		"build_name": "frontend ci",
+		"build_stage": "builder",
+		"build_status": "pending",
+		"build_created_at": "2022-11-11 20:01:51 UTC",
+		"build_started_at": null,
+		"build_finished_at": null,
+		"build_duration": null,
+		"build_queued_duration": 0.043838425,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 692601837,
+		"runner": null,
+		"project_id": 763808,
+		"project_name": "FuturePortal / RickvanderStaaij",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 692601837,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "created",
+			"duration": null,
+			"started_at": null,
+			"finished_at": null
+		},
+		"repository": {
+			"name": "RickvanderStaaij",
+			"url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"description": "https://rick.nu source code",
+			"homepage": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"visibility_level": 20
+		},
+		"environment": null
+	}
+}

--- a/cypress/fixtures/gitlab/canceled-pipeline/9.json
+++ b/cypress/fixtures/gitlab/canceled-pipeline/9.json
@@ -1,0 +1,264 @@
+{
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/15.6.0-pre",
+		"x-gitlab-event": "Pipeline Hook",
+		"x-gitlab-instance": "https://gitlab.com",
+		"accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+	},
+	"body": {
+		"object_kind": "pipeline",
+		"object_attributes": {
+			"id": 692601837,
+			"iid": 954,
+			"ref": "production",
+			"tag": false,
+			"sha": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"before_sha": "0000000000000000000000000000000000000000",
+			"source": "web",
+			"status": "pending",
+			"detailed_status": "pending",
+			"stages": ["builder", "cache", "test", "build", "deploy", "merge back"],
+			"created_at": "2022-11-11 20:01:51 UTC",
+			"finished_at": null,
+			"duration": null,
+			"queued_duration": null,
+			"variables": []
+		},
+		"merge_request": null,
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"project": {
+			"id": 763808,
+			"name": "RickvanderStaaij",
+			"description": "https://rick.nu source code",
+			"web_url": "https://gitlab.com/FuturePortal/RickvanderStaaij",
+			"avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/763808/avatar-blue.png",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/RickvanderStaaij.git",
+			"git_http_url": "https://gitlab.com/FuturePortal/RickvanderStaaij.git",
+			"namespace": "FuturePortal",
+			"visibility_level": 20,
+			"path_with_namespace": "FuturePortal/RickvanderStaaij",
+			"default_branch": "production",
+			"ci_config_path": null
+		},
+		"commit": {
+			"id": "2c55f17d517d720c120cfc0e76873454ada29b52",
+			"message": "Downgrade to node 16 for the current production state\n",
+			"title": "Downgrade to node 16 for the current production state",
+			"timestamp": "2022-11-11T19:05:51+01:00",
+			"url": "https://gitlab.com/FuturePortal/RickvanderStaaij/-/commit/2c55f17d517d720c120cfc0e76873454ada29b52",
+			"author": {
+				"name": "Rick van der Staaij",
+				"email": "[REDACTED]"
+			}
+		},
+		"builds": [
+			{
+				"id": 3312231243,
+				"stage": "cache",
+				"name": "frontend cache",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231245,
+				"stage": "test",
+				"name": "codestyle",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231247,
+				"stage": "test",
+				"name": "typescript",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231250,
+				"stage": "build",
+				"name": "frontend image",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231254,
+				"stage": "deploy",
+				"name": "deploy to production",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:52 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": {
+					"name": "production",
+					"action": "start",
+					"deployment_tier": "production"
+				}
+			},
+			{
+				"id": 3312231255,
+				"stage": "merge back",
+				"name": "update branches",
+				"status": "created",
+				"created_at": "2022-11-11 20:01:52 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": null,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			},
+			{
+				"id": 3312231241,
+				"stage": "builder",
+				"name": "frontend ci",
+				"status": "pending",
+				"created_at": "2022-11-11 20:01:51 UTC",
+				"started_at": null,
+				"finished_at": null,
+				"duration": null,
+				"queued_duration": 0.304193932,
+				"failure_reason": null,
+				"when": "on_success",
+				"manual": false,
+				"allow_failure": false,
+				"user": {
+					"id": 203336,
+					"name": "Rick van der Staaij",
+					"username": "rick.nu",
+					"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+					"email": "[REDACTED]"
+				},
+				"runner": null,
+				"artifacts_file": {
+					"filename": null,
+					"size": null
+				},
+				"environment": null
+			}
+		]
+	}
+}

--- a/cypress/integration/gitlab/canceled-pipeline.spec.js
+++ b/cypress/integration/gitlab/canceled-pipeline.spec.js
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+
+context('A running GitLab pipeline', () => {
+	it('opens the CIMonitor dashboard', () => {
+		cy.visit('/');
+	});
+
+	it('creates a pending pipeline', () => {
+		// Quickly go through the initial created pushes
+		for (let count = 1; count <= 8; count++) {
+			cy.gitlab(`canceled-pipeline/${count}`);
+		}
+	});
+
+	it('test pushes pipeline step by step', () => {
+		// Push all created events
+		for (let count = 9; count <= 20; count++) {
+			if (count > 1) {
+				cy.wait(300);
+			}
+			cy.gitlab(`canceled-pipeline/${count}`);
+		}
+	});
+});

--- a/frontend/App/Statuses/Status/Process/Process.style.tsx
+++ b/frontend/App/Statuses/Status/Process/Process.style.tsx
@@ -43,9 +43,15 @@ export const Stage = styled.div<StageProps>`
 	`)}
 
 	${(props) =>
+		['stopped'].includes(props.state) &&
+		css`
+			background: ${stateDarkColor.info};
+		`}
+
+	${(props) =>
 		['running'].includes(props.state) &&
 		css`
-			background: ${stateDarkColor['warning']};
+			background: ${stateDarkColor.warning};
 		`}
 
 	${(props) =>
@@ -57,7 +63,7 @@ export const Stage = styled.div<StageProps>`
 	${(props) =>
 		['failed', 'timeout'].includes(props.state) &&
 		css`
-			background: ${stateDarkColor['error']};
+			background: ${stateDarkColor.error};
 		`}
 `;
 

--- a/frontend/App/Statuses/Status/Process/Process.style.tsx
+++ b/frontend/App/Statuses/Status/Process/Process.style.tsx
@@ -48,13 +48,13 @@ export const Stage = styled.div<StageProps>`
 			background: ${stateDarkColor['warning']};
 		`}
 
-    ${(props) =>
+	${(props) =>
 		['pending'].includes(props.state) &&
 		css`
 			background: ${opacity(stateDarkColor[props.processState], 0.5)};
 		`}
 
-    ${(props) =>
+	${(props) =>
 		['failed', 'timeout'].includes(props.state) &&
 		css`
 			background: ${stateDarkColor['error']};
@@ -67,7 +67,7 @@ type StepProps = {
 };
 
 export const Step = styled.div<StepProps>`
-	background: ${(props) => stateDarkColor[props.state]};
+	background: ${(props) => stateDarkColor[props.state] || stateDarkColor.info};
 	padding: 0.3rem 0.5rem 0.3rem 2.3rem;
 	${ellipsis};
 
@@ -89,7 +89,7 @@ export const Step = styled.div<StepProps>`
 			background: ${opacity(stateDarkColor[props.processState], 0.5)};
 		`}
 
-    ${(props) =>
+	${(props) =>
 		['failed', 'timeout'].includes(props.state) &&
 		css`
 			background: ${stateDarkColor.error};

--- a/frontend/App/Statuses/Status/Process/Process.tsx
+++ b/frontend/App/Statuses/Status/Process/Process.tsx
@@ -19,6 +19,7 @@ const getStateIcon = (state: StepState, processState: State = 'warning') => {
 		pending: processState === 'warning' ? 'update' : 'skip_next',
 		created: 'push_pin',
 		skipped: 'skip_next',
+		stopped: 'stop_circle',
 		timeout: 'alarm',
 	};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cimonitor",
-	"version": "4.6.1",
+	"version": "4.7.0",
 	"description": "Monitors all your projects CI automatically",
 	"repository": "git@github.com:FuturePortal/CIMonitor.git",
 	"license": "MIT",

--- a/types/gitlab.ts
+++ b/types/gitlab.ts
@@ -1,3 +1,5 @@
+export type GitLabStatus = 'canceled' | 'pending' | 'running' | 'success' | 'failed' | 'created';
+
 export type GitLabUser = {
 	id: number;
 	name: string;
@@ -40,7 +42,7 @@ export type GitLabPipeline = {
 		sha: string;
 		before_sha: string;
 		source: string;
-		status: string;
+		status: GitLabStatus;
 		detailed_status: string;
 		stages: string[];
 		created_at: string;
@@ -64,7 +66,7 @@ export type GitLabPipeline = {
 
 export type GitLabDeployment = {
 	object_kind: 'deployment';
-	status: string;
+	status: GitLabStatus;
 	status_changed_at: string;
 	deployment_id: number;
 	deployable_id: number;
@@ -113,7 +115,7 @@ export type GitLabBuild = {
 	build_id: number;
 	build_name: string;
 	build_stage: string;
-	build_status: string;
+	build_status: GitLabStatus;
 	build_created_at: string;
 	build_started_at: string | null;
 	build_finished_at: string | null;

--- a/types/status.ts
+++ b/types/status.ts
@@ -8,7 +8,8 @@ export type StepState =
 	| 'failed'
 	| 'soft-failed'
 	| 'skipped'
-	| 'timeout';
+	| 'timeout'
+	| 'stopped';
 
 export type Step = {
 	id: string;


### PR DESCRIPTION
# What

Add step stopped state coming from a gitlab canceled job.

## Why

When a GitLab job got canceled, this resulted in a broken step state:

![image](https://user-images.githubusercontent.com/6495166/201415890-20273416-d05a-4013-bc53-00669182e0ad.png)

This PR should give it a proper info state and a stopped icon.
