### PR TITLE
Add GitLab deployment URL in status

### DIFF
--- a/backend/parser/gitlab/deployment.ts
+++ b/backend/parser/gitlab/deployment.ts
@@ -34,7 +34,7 @@ class GitLabDeploymentParser {
 			userImage: deployment.user.avatar_url,
 			userUrl: deployment.user_url,
 			sourceUrl: deployment.project.git_http_url,
-			tag: deployment.environment,
+			url: deployment.environment_external_url,
 			time: new Date().toUTCString(),
 		};
 	}

--- a/cypress/fixtures/gitlab/branch-with-mr/55.json
+++ b/cypress/fixtures/gitlab/branch-with-mr/55.json
@@ -1,46 +1,48 @@
 {
-    "headers": {
-        "content-type": "application/json",
-        "user-agent": "GitLab/14.10.0-pre",
-        "x-gitlab-event": "Deployment Hook"
-    },
-    "body": {
-        "object_kind": "deployment",
-        "status": "running",
-        "status_changed_at": "2022-04-09 19:29:59 +0000",
-        "deployment_id": 272924541,
-        "deployable_id": 2314349292,
-        "deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2314349292",
-        "environment": "review/74",
-        "project": {
-            "id": 33715538,
-            "name": "Nawcast",
-            "description": "https://nawcast.com",
-            "web_url": "https://gitlab.com/FuturePortal/Nawcast",
-            "avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
-            "git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
-            "namespace": "FuturePortal",
-            "visibility_level": 0,
-            "path_with_namespace": "FuturePortal/Nawcast",
-            "default_branch": "master",
-            "ci_config_path": null,
-            "homepage": "https://gitlab.com/FuturePortal/Nawcast",
-            "url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
-        },
-        "short_sha": "70b15b53",
-        "user": {
-            "id": 203336,
-            "name": "Rick van der Staaij",
-            "username": "rick.nu",
-            "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
-            "email": "[REDACTED]"
-        },
-        "user_url": "https://gitlab.com/rick.nu",
-        "commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/70b15b53ded5151bb15efa80279f4cc732996717",
-        "commit_title": "[#74] Add web frame slide type in the dashboard",
-        "ref": "74"
-    }
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/14.10.0-pre",
+		"x-gitlab-event": "Deployment Hook"
+	},
+	"body": {
+		"object_kind": "deployment",
+		"status": "running",
+		"status_changed_at": "2022-04-09 19:29:59 +0000",
+		"deployment_id": 272924541,
+		"deployable_id": 2314349292,
+		"deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2314349292",
+		"environment": "review/74",
+		"environment_slug": "74",
+		"environment_external_url": "https://74.main.nawcast.com",
+		"project": {
+			"id": 33715538,
+			"name": "Nawcast",
+			"description": "https://nawcast.com",
+			"web_url": "https://gitlab.com/FuturePortal/Nawcast",
+			"avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
+			"namespace": "FuturePortal",
+			"visibility_level": 0,
+			"path_with_namespace": "FuturePortal/Nawcast",
+			"default_branch": "master",
+			"ci_config_path": null,
+			"homepage": "https://gitlab.com/FuturePortal/Nawcast",
+			"url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
+		},
+		"short_sha": "70b15b53",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"user_url": "https://gitlab.com/rick.nu",
+		"commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/70b15b53ded5151bb15efa80279f4cc732996717",
+		"commit_title": "[#74] Add web frame slide type in the dashboard",
+		"ref": "74"
+	}
 }

--- a/cypress/fixtures/gitlab/branch-with-mr/56.json
+++ b/cypress/fixtures/gitlab/branch-with-mr/56.json
@@ -1,46 +1,48 @@
 {
-    "headers": {
-        "content-type": "application/json",
-        "user-agent": "GitLab/14.10.0-pre",
-        "x-gitlab-event": "Deployment Hook"
-    },
-    "body": {
-        "object_kind": "deployment",
-        "status": "success",
-        "status_changed_at": "2022-04-09 19:31:07 +0000",
-        "deployment_id": 272924541,
-        "deployable_id": 2314349292,
-        "deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2314349292",
-        "environment": "review/74",
-        "project": {
-            "id": 33715538,
-            "name": "Nawcast",
-            "description": "https://nawcast.com",
-            "web_url": "https://gitlab.com/FuturePortal/Nawcast",
-            "avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
-            "git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
-            "namespace": "FuturePortal",
-            "visibility_level": 0,
-            "path_with_namespace": "FuturePortal/Nawcast",
-            "default_branch": "master",
-            "ci_config_path": null,
-            "homepage": "https://gitlab.com/FuturePortal/Nawcast",
-            "url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
-        },
-        "short_sha": "70b15b53",
-        "user": {
-            "id": 203336,
-            "name": "Rick van der Staaij",
-            "username": "rick.nu",
-            "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
-            "email": "[REDACTED]"
-        },
-        "user_url": "https://gitlab.com/rick.nu",
-        "commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/70b15b53ded5151bb15efa80279f4cc732996717",
-        "commit_title": "[#74] Add web frame slide type in the dashboard",
-        "ref": "74"
-    }
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/14.10.0-pre",
+		"x-gitlab-event": "Deployment Hook"
+	},
+	"body": {
+		"object_kind": "deployment",
+		"status": "success",
+		"status_changed_at": "2022-04-09 19:31:07 +0000",
+		"deployment_id": 272924541,
+		"deployable_id": 2314349292,
+		"deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2314349292",
+		"environment": "review/74",
+		"environment_slug": "74",
+		"environment_external_url": "https://74.main.nawcast.com",
+		"project": {
+			"id": 33715538,
+			"name": "Nawcast",
+			"description": "https://nawcast.com",
+			"web_url": "https://gitlab.com/FuturePortal/Nawcast",
+			"avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
+			"namespace": "FuturePortal",
+			"visibility_level": 0,
+			"path_with_namespace": "FuturePortal/Nawcast",
+			"default_branch": "master",
+			"ci_config_path": null,
+			"homepage": "https://gitlab.com/FuturePortal/Nawcast",
+			"url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
+		},
+		"short_sha": "70b15b53",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"user_url": "https://gitlab.com/rick.nu",
+		"commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/70b15b53ded5151bb15efa80279f4cc732996717",
+		"commit_title": "[#74] Add web frame slide type in the dashboard",
+		"ref": "74"
+	}
 }

--- a/cypress/fixtures/gitlab/deployment/1.json
+++ b/cypress/fixtures/gitlab/deployment/1.json
@@ -1,46 +1,48 @@
 {
-    "headers": {
-        "content-type": "application/json",
-        "user-agent": "GitLab/14.9.0-pre",
-        "x-gitlab-event": "Deployment Hook"
-    },
-    "body": {
-        "object_kind": "deployment",
-        "status": "running",
-        "status_changed_at": "2022-03-21 11:33:35 +0000",
-        "deployment_id": 263364082,
-        "deployable_id": 2228389648,
-        "deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2228389648",
-        "environment": "review/10",
-        "project": {
-            "id": 33715538,
-            "name": "Nawcast",
-            "description": "https://nawcast.com",
-            "web_url": "https://gitlab.com/FuturePortal/Nawcast",
-            "avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
-            "git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
-            "namespace": "FuturePortal",
-            "visibility_level": 0,
-            "path_with_namespace": "FuturePortal/Nawcast",
-            "default_branch": "master",
-            "ci_config_path": null,
-            "homepage": "https://gitlab.com/FuturePortal/Nawcast",
-            "url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
-        },
-        "short_sha": "16f8102b",
-        "user": {
-            "id": 203336,
-            "name": "Rick van der Staaij",
-            "username": "rick.nu",
-            "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
-            "email": "[REDACTED]"
-        },
-        "user_url": "https://gitlab.com/rick.nu",
-        "commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/16f8102b00f7687cd911b1240a086fef9ae5e2c1",
-        "commit_title": "Merge branch '73' into 'master'",
-        "ref": "10"
-    }
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/14.9.0-pre",
+		"x-gitlab-event": "Deployment Hook"
+	},
+	"body": {
+		"object_kind": "deployment",
+		"status": "running",
+		"status_changed_at": "2022-03-21 11:33:35 +0000",
+		"deployment_id": 263364082,
+		"deployable_id": 2228389648,
+		"deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2228389648",
+		"environment": "review/10",
+		"environment_slug": "10",
+		"environment_external_url": "https://10.main.nawcast.com",
+		"project": {
+			"id": 33715538,
+			"name": "Nawcast",
+			"description": "https://nawcast.com",
+			"web_url": "https://gitlab.com/FuturePortal/Nawcast",
+			"avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
+			"namespace": "FuturePortal",
+			"visibility_level": 0,
+			"path_with_namespace": "FuturePortal/Nawcast",
+			"default_branch": "master",
+			"ci_config_path": null,
+			"homepage": "https://gitlab.com/FuturePortal/Nawcast",
+			"url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
+		},
+		"short_sha": "16f8102b",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"user_url": "https://gitlab.com/rick.nu",
+		"commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/16f8102b00f7687cd911b1240a086fef9ae5e2c1",
+		"commit_title": "Merge branch '73' into 'master'",
+		"ref": "10"
+	}
 }

--- a/cypress/fixtures/gitlab/deployment/2.json
+++ b/cypress/fixtures/gitlab/deployment/2.json
@@ -1,46 +1,48 @@
 {
-    "headers": {
-        "content-type": "application/json",
-        "user-agent": "GitLab/14.9.0-pre",
-        "x-gitlab-event": "Deployment Hook"
-    },
-    "body": {
-        "object_kind": "deployment",
-        "status": "success",
-        "status_changed_at": "2022-03-21 11:34:38 +0000",
-        "deployment_id": 263364082,
-        "deployable_id": 2228389648,
-        "deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2228389648",
-        "environment": "review/10",
-        "project": {
-            "id": 33715538,
-            "name": "Nawcast",
-            "description": "https://nawcast.com",
-            "web_url": "https://gitlab.com/FuturePortal/Nawcast",
-            "avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
-            "git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
-            "namespace": "FuturePortal",
-            "visibility_level": 0,
-            "path_with_namespace": "FuturePortal/Nawcast",
-            "default_branch": "master",
-            "ci_config_path": null,
-            "homepage": "https://gitlab.com/FuturePortal/Nawcast",
-            "url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
-        },
-        "short_sha": "16f8102b",
-        "user": {
-            "id": 203336,
-            "name": "Rick van der Staaij",
-            "username": "rick.nu",
-            "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
-            "email": "[REDACTED]"
-        },
-        "user_url": "https://gitlab.com/rick.nu",
-        "commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/16f8102b00f7687cd911b1240a086fef9ae5e2c1",
-        "commit_title": "Merge branch '73' into 'master'",
-        "ref": "10"
-    }
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/14.9.0-pre",
+		"x-gitlab-event": "Deployment Hook"
+	},
+	"body": {
+		"object_kind": "deployment",
+		"status": "success",
+		"status_changed_at": "2022-03-21 11:34:38 +0000",
+		"deployment_id": 263364082,
+		"deployable_id": 2228389648,
+		"deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2228389648",
+		"environment": "review/10",
+		"environment_slug": "10",
+		"environment_external_url": "https://10.main.nawcast.com",
+		"project": {
+			"id": 33715538,
+			"name": "Nawcast",
+			"description": "https://nawcast.com",
+			"web_url": "https://gitlab.com/FuturePortal/Nawcast",
+			"avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
+			"namespace": "FuturePortal",
+			"visibility_level": 0,
+			"path_with_namespace": "FuturePortal/Nawcast",
+			"default_branch": "master",
+			"ci_config_path": null,
+			"homepage": "https://gitlab.com/FuturePortal/Nawcast",
+			"url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
+		},
+		"short_sha": "16f8102b",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"user_url": "https://gitlab.com/rick.nu",
+		"commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/16f8102b00f7687cd911b1240a086fef9ae5e2c1",
+		"commit_title": "Merge branch '73' into 'master'",
+		"ref": "10"
+	}
 }

--- a/cypress/fixtures/gitlab/pipeline/53.json
+++ b/cypress/fixtures/gitlab/pipeline/53.json
@@ -1,46 +1,48 @@
 {
-    "headers": {
-        "content-type": "application/json",
-        "user-agent": "GitLab/14.9.0-pre",
-        "x-gitlab-event": "Deployment Hook"
-    },
-    "body": {
-        "object_kind": "deployment",
-        "status": "running",
-        "status_changed_at": "2022-03-21 11:33:35 +0000",
-        "deployment_id": 263364082,
-        "deployable_id": 2228389648,
-        "deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2228389648",
-        "environment": "production",
-        "project": {
-            "id": 33715538,
-            "name": "Nawcast",
-            "description": "https://nawcast.com",
-            "web_url": "https://gitlab.com/FuturePortal/Nawcast",
-            "avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
-            "git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
-            "namespace": "FuturePortal",
-            "visibility_level": 0,
-            "path_with_namespace": "FuturePortal/Nawcast",
-            "default_branch": "master",
-            "ci_config_path": null,
-            "homepage": "https://gitlab.com/FuturePortal/Nawcast",
-            "url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
-        },
-        "short_sha": "16f8102b",
-        "user": {
-            "id": 203336,
-            "name": "Rick van der Staaij",
-            "username": "rick.nu",
-            "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
-            "email": "[REDACTED]"
-        },
-        "user_url": "https://gitlab.com/rick.nu",
-        "commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/16f8102b00f7687cd911b1240a086fef9ae5e2c1",
-        "commit_title": "Merge branch '73' into 'master'",
-        "ref": "master"
-    }
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/14.9.0-pre",
+		"x-gitlab-event": "Deployment Hook"
+	},
+	"body": {
+		"object_kind": "deployment",
+		"status": "running",
+		"status_changed_at": "2022-03-21 11:33:35 +0000",
+		"deployment_id": 263364082,
+		"deployable_id": 2228389648,
+		"deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2228389648",
+		"environment": "production",
+		"environment_slug": "production",
+		"environment_external_url": "https://nawcast.com",
+		"project": {
+			"id": 33715538,
+			"name": "Nawcast",
+			"description": "https://nawcast.com",
+			"web_url": "https://gitlab.com/FuturePortal/Nawcast",
+			"avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
+			"namespace": "FuturePortal",
+			"visibility_level": 0,
+			"path_with_namespace": "FuturePortal/Nawcast",
+			"default_branch": "master",
+			"ci_config_path": null,
+			"homepage": "https://gitlab.com/FuturePortal/Nawcast",
+			"url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
+		},
+		"short_sha": "16f8102b",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"user_url": "https://gitlab.com/rick.nu",
+		"commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/16f8102b00f7687cd911b1240a086fef9ae5e2c1",
+		"commit_title": "Merge branch '73' into 'master'",
+		"ref": "master"
+	}
 }

--- a/cypress/fixtures/gitlab/pipeline/54.json
+++ b/cypress/fixtures/gitlab/pipeline/54.json
@@ -1,46 +1,48 @@
 {
-    "headers": {
-        "content-type": "application/json",
-        "user-agent": "GitLab/14.9.0-pre",
-        "x-gitlab-event": "Deployment Hook"
-    },
-    "body": {
-        "object_kind": "deployment",
-        "status": "success",
-        "status_changed_at": "2022-03-21 11:34:38 +0000",
-        "deployment_id": 263364082,
-        "deployable_id": 2228389648,
-        "deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2228389648",
-        "environment": "production",
-        "project": {
-            "id": 33715538,
-            "name": "Nawcast",
-            "description": "https://nawcast.com",
-            "web_url": "https://gitlab.com/FuturePortal/Nawcast",
-            "avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
-            "git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
-            "namespace": "FuturePortal",
-            "visibility_level": 0,
-            "path_with_namespace": "FuturePortal/Nawcast",
-            "default_branch": "master",
-            "ci_config_path": null,
-            "homepage": "https://gitlab.com/FuturePortal/Nawcast",
-            "url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
-        },
-        "short_sha": "16f8102b",
-        "user": {
-            "id": 203336,
-            "name": "Rick van der Staaij",
-            "username": "rick.nu",
-            "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
-            "email": "[REDACTED]"
-        },
-        "user_url": "https://gitlab.com/rick.nu",
-        "commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/16f8102b00f7687cd911b1240a086fef9ae5e2c1",
-        "commit_title": "Merge branch '73' into 'master'",
-        "ref": "master"
-    }
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/14.9.0-pre",
+		"x-gitlab-event": "Deployment Hook"
+	},
+	"body": {
+		"object_kind": "deployment",
+		"status": "success",
+		"status_changed_at": "2022-03-21 11:34:38 +0000",
+		"deployment_id": 263364082,
+		"deployable_id": 2228389648,
+		"deployable_url": "https://gitlab.com/FuturePortal/Nawcast/-/jobs/2228389648",
+		"environment": "master",
+		"environment_slug": "production",
+		"environment_external_url": "https://nawcast.com",
+		"project": {
+			"id": 33715538,
+			"name": "Nawcast",
+			"description": "https://nawcast.com",
+			"web_url": "https://gitlab.com/FuturePortal/Nawcast",
+			"avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/33715538/api.png",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
+			"namespace": "FuturePortal",
+			"visibility_level": 0,
+			"path_with_namespace": "FuturePortal/Nawcast",
+			"default_branch": "master",
+			"ci_config_path": null,
+			"homepage": "https://gitlab.com/FuturePortal/Nawcast",
+			"url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"http_url": "https://gitlab.com/FuturePortal/Nawcast.git"
+		},
+		"short_sha": "16f8102b",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"user_url": "https://gitlab.com/rick.nu",
+		"commit_url": "https://gitlab.com/FuturePortal/Nawcast/-/commit/16f8102b00f7687cd911b1240a086fef9ae5e2c1",
+		"commit_title": "Merge branch '73' into 'master'",
+		"ref": "master"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cimonitor",
-	"version": "4.7.0",
+	"version": "4.8.0",
 	"description": "Monitors all your projects CI automatically",
 	"repository": "git@github.com:FuturePortal/CIMonitor.git",
 	"license": "MIT",

--- a/types/gitlab.ts
+++ b/types/gitlab.ts
@@ -72,6 +72,8 @@ export type GitLabDeployment = {
 	deployable_id: number;
 	deployable_url: string;
 	environment: string;
+	environment_slug?: string;
+	environment_external_url?: string;
 	short_sha: string;
 	user_url: string;
 	commit_url: string;


### PR DESCRIPTION
# What

With this PR, the external environment URL from a GitLab deployment, is shown in the status cards. This is possible thanks to my [GitLab core contribution](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/105021) :star_struck:.

Note: even though the `environment_exteranl_url` only becomes available in GitLab 15.7, this code can be merged safily already. CIMonitor will work just fine when the field is not provided yet in the webhook.

## Why

![image](https://user-images.githubusercontent.com/6495166/204886625-8cefc26f-057c-4882-b41c-45736d9523a6.png)

Now becommes:

![image](https://user-images.githubusercontent.com/6495166/204886452-3f4b3c20-4f5b-44a6-b09d-bbeec2ecc116.png)

And the link is clickable!

