### PR TITLE
On mobile devices, only show tab icons in the settings panel

### DIFF
--- a/frontend/App/SettingsPanel/SettingsPanel.style.tsx
+++ b/frontend/App/SettingsPanel/SettingsPanel.style.tsx
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 
 import { stateColor, stateDarkColor, textColor } from '/frontend/style/colors';
+import { fromSize } from '/frontend/style/size';
 
 export const Overlay = styled.div`
 	position: fixed;
@@ -59,11 +60,15 @@ export const Tabs = styled.div`
 	background: ${stateColor.success};
 `;
 
-type TabProps = {
-	active: boolean;
-};
+export const TabText = styled.span`
+	display: none;
 
-export const Tab = styled.button<TabProps>`
+	${fromSize.medium(css`
+		display: inline;
+	`)}
+`;
+
+export const Tab = styled.button<{ active: boolean }>`
 	padding: 0.8rem 1rem;
 
 	${(props) =>

--- a/frontend/App/SettingsPanel/SettingsPanel.tsx
+++ b/frontend/App/SettingsPanel/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { Close, Frame, Overlay, Tab, Tabs, Title, TitleBar } from './SettingsPanel.style';
+import { Close, Frame, Overlay, Tab, Tabs, TabText, Title, TitleBar } from './SettingsPanel.style';
 
 import Icon from '/frontend/components/Icon';
 import { closeSettingsPanel } from '/frontend/store/settings/actions';
@@ -70,7 +70,7 @@ const SettingsPanel = (): ReactElement => {
 				<Tabs>
 					{tabs.map((tab) => (
 						<Tab active={tab.icon === activeTab} key={tab.icon} onClick={() => setActiveTab(tab.icon)}>
-							<Icon icon={tab.icon} /> {tab.name}
+							<Icon icon={tab.icon} /> <TabText>{tab.name}</TabText>
 						</Tab>
 					))}
 				</Tabs>


### PR DESCRIPTION
# What

Mobile devices:

![image](https://user-images.githubusercontent.com/6495166/206503995-8b924d67-01df-4fb6-b1cc-9117a8c630a8.png)

Desktop:

![image](https://user-images.githubusercontent.com/6495166/206503279-5a9a3ec0-c70f-4365-ae1a-06c4199cb387.png)

## Why

Previous mobile view:

![image](https://user-images.githubusercontent.com/6495166/206503760-36fbfd04-feed-409c-bebf-aa71227eb201.png)

