### PR TITLE
Change avatar toggle logic, all options off by default

### DIFF
--- a/frontend/App/SettingsPanel/Customization/Customization.tsx
+++ b/frontend/App/SettingsPanel/Customization/Customization.tsx
@@ -8,12 +8,12 @@ import Icon from '/frontend/components/Icon';
 import Modifier from '/frontend/components/Modifier';
 import Toggle from '/frontend/components/Toggle';
 import { setSizeModifier, toggleShowCompleted, toggleShowUserAvatars } from '/frontend/store/settings/actions';
-import { getSizeModifier, isShowingCompleted, isShowingUserAvatars } from '/frontend/store/settings/selectors';
+import { getSizeModifier, isHidingUserAvatars, isShowingCompleted } from '/frontend/store/settings/selectors';
 
 const Customization = (): ReactElement => {
 	const showCompleted = useSelector(isShowingCompleted);
 	const sizeModifier = useSelector(getSizeModifier);
-	const showUserAvatars = useSelector(isShowingUserAvatars);
+	const isHidingAvatars = useSelector(isHidingUserAvatars);
 	const dispatch = useDispatch();
 
 	const server = <Icon icon="warning" state="warning" title="Server setting" />;
@@ -37,11 +37,11 @@ const Customization = (): ReactElement => {
 			</Setting>
 			<Setting>
 				<About>
-					<Title>Show user avatars</Title>
+					<Title>Hide user avatars</Title>
 					<Description>Do you want to see the user avatar images?</Description>
 				</About>
 				<Tool>
-					<Toggle onToggle={() => dispatch(toggleShowUserAvatars())} enabled={showUserAvatars} />
+					<Toggle onToggle={() => dispatch(toggleShowUserAvatars())} enabled={isHidingAvatars} />
 				</Tool>
 			</Setting>
 			<Setting>

--- a/frontend/App/Statuses/Status/Status.tsx
+++ b/frontend/App/Statuses/Status/Status.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { Body, Box, Boxes, Container, Details, LinkBox, Project, UserImage } from './Status.style';
 
 import Icon from '/frontend/components/Icon';
-import { isShowingUserAvatars } from '/frontend/store/settings/selectors';
+import { isHidingUserAvatars } from '/frontend/store/settings/selectors';
 
 import Merge from './Merge';
 import Process from './Process';
@@ -27,7 +27,7 @@ const pettyUrl = (url: string) =>
 		.replace(/\/$/, '');
 
 const Statuses = ({ status }: Props): ReactElement => {
-	const showUserAvatar = useSelector(isShowingUserAvatars);
+	const hideUserAvatar = useSelector(isHidingUserAvatars);
 
 	return (
 		<Container key={status.id} state={status.state}>
@@ -59,7 +59,7 @@ const Statuses = ({ status }: Props): ReactElement => {
 						</Box>
 					</Boxes>
 				</Details>
-				{status.userImage && showUserAvatar && (
+				{status.userImage && !hideUserAvatar && (
 					<UserImage>
 						<img src={status.userImage} alt="User" />
 					</UserImage>

--- a/frontend/store/settings/selectors.ts
+++ b/frontend/store/settings/selectors.ts
@@ -4,7 +4,7 @@ export const isSettingsPanelOpen = (state: RootState): boolean => state.setting.
 
 export const isShowingCompleted = (state: RootState): boolean => state.setting.showCompleted;
 
-export const isShowingUserAvatars = (state: RootState): boolean => state.setting.showUserAvatars;
+export const isHidingUserAvatars = (state: RootState): boolean => !state.setting.showUserAvatars;
 
 export const getSizeModifier = (state: RootState): number =>
 	state.setting.sizeModifier ? state.setting.sizeModifier : 1;


### PR DESCRIPTION
# What

- This PR changes "Show user avatars: true" to "Hide user avatars: false"
- Noting should change settings wise, only the way it is displayed

## Why

I feel that all optional settings should be off by default, and you can enable them if you want to.
