### PR TITLE
Add more documentation on how to run a module client

### DIFF
--- a/docs/module-client.md
+++ b/docs/module-client.md
@@ -23,7 +23,7 @@ and insert the contents:
 @xset s off
 @xset -dpms
 @xset s noblank
-@chromium-browser --kiosk https://ci.yourwebsite.com
+@chromium-browser --kiosk https://ci.example.com
 ```
 
 you might also want to hide the mouse, install unclutter:
@@ -102,6 +102,6 @@ docker run \
     --volume /lib/libwiringPi.so:/lib/libwiringPi.so \
     --volume /dev/mem:/dev/mem \
     --volume /dev/gpiomem:/dev/gpiomem \
-    --env CIMONITOR_SERVER_URL="https://ci.craft.enrise.com" \
+    --env CIMONITOR_SERVER_URL="https://ci.example.com" \
     cimonitor/module-client:latest-arm
 ```

--- a/docs/module-client.md
+++ b/docs/module-client.md
@@ -1,3 +1,107 @@
 # Module client
 
-todo: `cimonitor/module-client:latest`
+In this documentation we will teach you how to run a module-client on a Raspberry Pi. Note that this is
+not very complete information yet, but it should give you some pointers at least.
+
+## Install docker
+
+https://docs.docker.com/engine/install/raspberry-pi-os/#install-using-the-repository
+
+## Using GPIO modules?
+
+http://wiringpi.com/download-and-install/
+
+## Starting CIMonitor on a display (optional)
+
+```shell
+sudo vim /etc/xdg/lxsession/LXDE-pi/autostart
+```
+
+and insert the contents:
+
+```
+@xset s off
+@xset -dpms
+@xset s noblank
+@chromium-browser --kiosk https://ci.yourwebsite.com
+```
+
+you might also want to hide the mouse, install unclutter:
+
+```shell
+sudo apt install unclutter
+```
+
+## Running module client
+
+Create a CIMonitor folder on your PI:
+
+```shell
+mkdir ~/CIMonitor;
+cd ~/CIMonitor;
+```
+
+## Create module config
+
+Create a `~/CIMonitor/storage/modules.json`:
+
+```json
+{
+	"triggers": [
+		{
+			"status": {
+				"state": "success",
+				"branch": "master"
+			},
+			"event": "celebrate"
+		},
+		{
+			"status": {
+				"state": "success",
+				"branch": "main"
+			},
+			"event": "celebrate"
+		},
+		{
+			"status": {
+				"state": "success",
+				"branch": "production"
+			},
+			"event": "celebrate"
+		}
+	],
+	"events": [
+		{
+			"name": "celebrate",
+			"modules": [
+				{
+					"type": "gpio",
+					"pin": 7,
+					"mode": "on-for",
+					"duration": 10000
+				}
+			]
+		}
+	]
+}
+```
+
+## Start docker container
+
+There, run the CIMonitor module client:
+
+```shell
+docker run \
+    --privileged \
+    --detach \
+    --restart unless-stopped \
+    --name CIMonitorClient \
+    --volume $(pwd)/storage:/CIMonitor/storage \
+    --volume /usr/bin/gpio:/usr/bin/gpio \
+    --volume /lib/libwiringPiDev.so:/lib/libwiringPiDev.so \
+    --volume /lib/libwiringPi.so:/lib/libwiringPi.so \
+    --volume /dev/mem:/dev/mem \
+    --volume /dev/gpiomem:/dev/gpiomem \
+    --env CIMONITOR_SERVER_URL="https://ci.craft.enrise.com" \
+    cimonitor/module-client:latest-arm
+```


### PR DESCRIPTION
# What

There was no documentation yet on how to use the module client. This PR adds all information required to at least get the basics running.

## Why

A module client can add a lot of fun to your CIMonitor setup.
