### PR TITLE
Don't override a running job to pending

### DIFF
--- a/backend/parser/gitlab/build.ts
+++ b/backend/parser/gitlab/build.ts
@@ -124,8 +124,6 @@ class GitLabBuildParser {
 
 		steps = steps.map((step) => {
 			if (step.id === stepId) {
-				// TODO: check if previous was running, and current is started, then ignore
-
 				const previousState = step.state;
 				const newState = statusToStepState(build.build_status, build.build_allow_failure);
 

--- a/cypress/fixtures/gitlab/branch-with-mr/16.json
+++ b/cypress/fixtures/gitlab/branch-with-mr/16.json
@@ -1,58 +1,58 @@
 {
-    "headers": {
-        "content-type": "application/json",
-        "user-agent": "GitLab/14.10.0-pre",
-        "x-gitlab-event": "Job Hook"
-    },
-    "body": {
-        "object_kind": "build",
-        "ref": "74",
-        "tag": false,
-        "before_sha": "057ffcf3b58f839c17fff0e022b8011eca4cf303",
-        "sha": "70b15b53ded5151bb15efa80279f4cc732996717",
-        "build_id": 2314349282,
-        "build_name": "api tests",
-        "build_stage": "test",
-        "build_status": "pending",
-        "build_created_at": "2022-04-09 19:26:31 UTC",
-        "build_started_at": null,
-        "build_finished_at": null,
-        "build_duration": null,
-        "build_queued_duration": 0.075305112,
-        "build_allow_failure": false,
-        "build_failure_reason": "unknown_failure",
-        "pipeline_id": 513076930,
-        "runner": null,
-        "project_id": 33715538,
-        "project_name": "FuturePortal / Nawcast",
-        "user": {
-            "id": 203336,
-            "name": "Rick van der Staaij",
-            "username": "rick.nu",
-            "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
-            "email": "[REDACTED]"
-        },
-        "commit": {
-            "id": 513076930,
-            "sha": "70b15b53ded5151bb15efa80279f4cc732996717",
-            "message": "[#74] Add web frame slide type in the dashboard\n",
-            "author_name": "Rick van der Staaij",
-            "author_email": "[REDACTED]",
-            "author_url": "https://gitlab.com/rick.nu",
-            "status": "created",
-            "duration": null,
-            "started_at": null,
-            "finished_at": null
-        },
-        "repository": {
-            "name": "Nawcast",
-            "url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "description": "https://nawcast.com",
-            "homepage": "https://gitlab.com/FuturePortal/Nawcast",
-            "git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
-            "git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "visibility_level": 0
-        },
-        "environment": null
-    }
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/14.10.0-pre",
+		"x-gitlab-event": "Job Hook"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "74",
+		"tag": false,
+		"before_sha": "057ffcf3b58f839c17fff0e022b8011eca4cf303",
+		"sha": "70b15b53ded5151bb15efa80279f4cc732996717",
+		"build_id": 2314349282,
+		"build_name": "api tests",
+		"build_stage": "test",
+		"build_status": "running",
+		"build_created_at": "2022-04-09 19:26:31 UTC",
+		"build_started_at": null,
+		"build_finished_at": null,
+		"build_duration": null,
+		"build_queued_duration": 0.075305112,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 513076930,
+		"runner": null,
+		"project_id": 33715538,
+		"project_name": "FuturePortal / Nawcast",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 513076930,
+			"sha": "70b15b53ded5151bb15efa80279f4cc732996717",
+			"message": "[#74] Add web frame slide type in the dashboard\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "created",
+			"duration": null,
+			"started_at": null,
+			"finished_at": null
+		},
+		"repository": {
+			"name": "Nawcast",
+			"url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"description": "https://nawcast.com",
+			"homepage": "https://gitlab.com/FuturePortal/Nawcast",
+			"git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"visibility_level": 0
+		},
+		"environment": null
+	}
 }

--- a/cypress/fixtures/gitlab/branch-with-mr/30.json
+++ b/cypress/fixtures/gitlab/branch-with-mr/30.json
@@ -1,65 +1,65 @@
 {
-    "headers": {
-        "content-type": "application/json",
-        "user-agent": "GitLab/14.10.0-pre",
-        "x-gitlab-event": "Job Hook"
-    },
-    "body": {
-        "object_kind": "build",
-        "ref": "74",
-        "tag": false,
-        "before_sha": "057ffcf3b58f839c17fff0e022b8011eca4cf303",
-        "sha": "70b15b53ded5151bb15efa80279f4cc732996717",
-        "build_id": 2314349282,
-        "build_name": "api tests",
-        "build_stage": "test",
-        "build_status": "running",
-        "build_created_at": "2022-04-09 19:26:31 UTC",
-        "build_started_at": "2022-04-09 19:26:33 UTC",
-        "build_finished_at": null,
-        "build_duration": 0.134215871,
-        "build_queued_duration": 2.140293,
-        "build_allow_failure": false,
-        "build_failure_reason": "unknown_failure",
-        "pipeline_id": 513076930,
-        "runner": {
-            "id": 13775607,
-            "description": "local.rick.nu",
-            "runner_type": "group_type",
-            "active": true,
-            "is_shared": false,
-            "tags": []
-        },
-        "project_id": 33715538,
-        "project_name": "FuturePortal / Nawcast",
-        "user": {
-            "id": 203336,
-            "name": "Rick van der Staaij",
-            "username": "rick.nu",
-            "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
-            "email": "[REDACTED]"
-        },
-        "commit": {
-            "id": 513076930,
-            "sha": "70b15b53ded5151bb15efa80279f4cc732996717",
-            "message": "[#74] Add web frame slide type in the dashboard\n",
-            "author_name": "Rick van der Staaij",
-            "author_email": "[REDACTED]",
-            "author_url": "https://gitlab.com/rick.nu",
-            "status": "running",
-            "duration": null,
-            "started_at": "2022-04-09 19:26:32 UTC",
-            "finished_at": null
-        },
-        "repository": {
-            "name": "Nawcast",
-            "url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "description": "https://nawcast.com",
-            "homepage": "https://gitlab.com/FuturePortal/Nawcast",
-            "git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
-            "git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
-            "visibility_level": 0
-        },
-        "environment": null
-    }
+	"headers": {
+		"content-type": "application/json",
+		"user-agent": "GitLab/14.10.0-pre",
+		"x-gitlab-event": "Job Hook"
+	},
+	"body": {
+		"object_kind": "build",
+		"ref": "74",
+		"tag": false,
+		"before_sha": "057ffcf3b58f839c17fff0e022b8011eca4cf303",
+		"sha": "70b15b53ded5151bb15efa80279f4cc732996717",
+		"build_id": 2314349282,
+		"build_name": "api tests",
+		"build_stage": "test",
+		"build_status": "pending",
+		"build_created_at": "2022-04-09 19:26:31 UTC",
+		"build_started_at": "2022-04-09 19:26:33 UTC",
+		"build_finished_at": null,
+		"build_duration": 0.134215871,
+		"build_queued_duration": 2.140293,
+		"build_allow_failure": false,
+		"build_failure_reason": "unknown_failure",
+		"pipeline_id": 513076930,
+		"runner": {
+			"id": 13775607,
+			"description": "local.rick.nu",
+			"runner_type": "group_type",
+			"active": true,
+			"is_shared": false,
+			"tags": []
+		},
+		"project_id": 33715538,
+		"project_name": "FuturePortal / Nawcast",
+		"user": {
+			"id": 203336,
+			"name": "Rick van der Staaij",
+			"username": "rick.nu",
+			"avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/203336/avatar.png",
+			"email": "[REDACTED]"
+		},
+		"commit": {
+			"id": 513076930,
+			"sha": "70b15b53ded5151bb15efa80279f4cc732996717",
+			"message": "[#74] Add web frame slide type in the dashboard\n",
+			"author_name": "Rick van der Staaij",
+			"author_email": "[REDACTED]",
+			"author_url": "https://gitlab.com/rick.nu",
+			"status": "running",
+			"duration": null,
+			"started_at": "2022-04-09 19:26:32 UTC",
+			"finished_at": null
+		},
+		"repository": {
+			"name": "Nawcast",
+			"url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"description": "https://nawcast.com",
+			"homepage": "https://gitlab.com/FuturePortal/Nawcast",
+			"git_http_url": "https://gitlab.com/FuturePortal/Nawcast.git",
+			"git_ssh_url": "git@gitlab.com:FuturePortal/Nawcast.git",
+			"visibility_level": 0
+		},
+		"environment": null
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cimonitor",
-	"version": "4.11.1",
+	"version": "4.11.2",
 	"description": "Monitors all your projects CI automatically",
 	"repository": "git@github.com:FuturePortal/CIMonitor.git",
 	"license": "MIT",


### PR DESCRIPTION
# What

- Don't override a `running` job to `pending`

## Why

Now, when a job is directly picked up by a GitLab runner, the `running` status is pushed direclty after the `pending` status. It can however happen that the webhooks with this updates are arriving in the wrong order. Marking a `running` job as `pending`, even though it's already running. This PR make sure CIMonitor doesn't override a `running` job with `pending`.

![image](https://github.com/FuturePortal/CIMonitor/assets/6495166/08c29f69-4694-47bb-adc8-3b41fdce7f9c)

