### PR TITLE
Improve mobile view for a status header and its images

### DIFF
--- a/frontend/App/Statuses/Status/ProjectImage/ProjectImage.style.tsx
+++ b/frontend/App/Statuses/Status/ProjectImage/ProjectImage.style.tsx
@@ -1,11 +1,16 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-export const Container = styled.div`
-	margin-right: 1rem;
+import { fromSize } from '/frontend/style/size';
 
-	img {
-		border-radius: 0.25rem;
-		max-width: 6rem;
-		max-height: 6rem;
-	}
+export const ProjectAvatar = styled.img`
+	border-radius: 0.25rem;
+	width: 3rem;
+	height: 3rem;
+	grid-row: 1;
+	grid-column: 1;
+
+	${fromSize.medium(css`
+		width: 6rem;
+		height: 6rem;
+	`)}
 `;

--- a/frontend/App/Statuses/Status/ProjectImage/ProjectImage.tsx
+++ b/frontend/App/Statuses/Status/ProjectImage/ProjectImage.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useState } from 'react';
 
-import { Container } from './ProjectImage.style';
+import { ProjectAvatar } from './ProjectImage.style';
 
 type Props = {
 	url: string;
@@ -14,11 +14,7 @@ const ProjectImage = ({ url, alt }: Props): ReactElement | null => {
 		return null;
 	}
 
-	return (
-		<Container>
-			<img src={url} alt={alt} onError={() => setNotLoading(true)} />
-		</Container>
-	);
+	return <ProjectAvatar src={url} alt={alt} onError={() => setNotLoading(true)} />;
 };
 
 export default ProjectImage;

--- a/frontend/App/Statuses/Status/Status.style.tsx
+++ b/frontend/App/Statuses/Status/Status.style.tsx
@@ -44,9 +44,13 @@ export const LinkBox = styled.a`
 `;
 
 export const Details = styled.div`
-	flex-grow: 1;
-	flex-shrink: 1;
 	min-width: 5rem;
+	grid-column: 2;
+	grid-row: 1 / 3;
+
+	${fromSize.medium(css`
+		grid-row: 1;
+	`)}
 `;
 
 export const Project = styled.h1`
@@ -94,15 +98,36 @@ export const Container = styled.div<StatusProps>`
 
 export const Body = styled.div`
 	padding: 0.75rem;
-	display: flex;
+	display: grid;
+	grid-template-columns: 1fr 50fr;
+	grid-template-rows: 3rem 1fr;
+	gap: 0.5rem;
+
+	${fromSize.medium(css`
+		grid-template-columns: 1fr 50fr 1fr;
+		grid-template-rows: 1fr;
+		gap: 1rem;
+	`)}
 `;
 
 export const UserImage = styled.div`
 	flex-shrink: 0;
+	grid-column: 1;
+	grid-row: 2;
+
+	${fromSize.medium(css`
+		grid-column: 3;
+		grid-row: 1;
+	`)}
 
 	img {
 		border-radius: 50%;
-		width: 6rem;
-		height: 6rem;
+		width: 3rem;
+		height: 3rem;
+
+		${fromSize.medium(css`
+			width: 6rem;
+			height: 6rem;
+		`)}
 	}
 `;


### PR DESCRIPTION
# What

Improves the mobile view for a status header and its images.

## Why

The images were very big, and left no more space for the labels. This is now improved, See the before and after:

before | after
--- | ---
![image](https://github.com/FuturePortal/CIMonitor/assets/6495166/29ecd036-1b97-4ffc-ae4f-1abe0f5aa23a) | ![image](https://github.com/FuturePortal/CIMonitor/assets/6495166/7839aa6f-6cb9-4612-b315-42e6a5a4d8fe)

