### PR TITLE
Add global state change event to the socket events

### DIFF
--- a/backend/socket/manager.ts
+++ b/backend/socket/manager.ts
@@ -4,7 +4,7 @@ import { Server as SocketServer } from 'socket.io';
 import StatusEvents from 'backend/status/events';
 import StatusManager from 'backend/status/manager';
 import { socketEvent } from 'types/cimonitor';
-import Status from 'types/status';
+import Status, { State } from 'types/status';
 
 class SocketManager {
 	socket = null;
@@ -47,6 +47,11 @@ class SocketManager {
 		StatusEvents.on(
 			StatusEvents.event.deleteAllStatuses,
 			() => this.socket && this.socket.sockets.emit(socketEvent.allStatuses, [])
+		);
+
+		StatusEvents.on(
+			StatusEvents.event.globalStateChange,
+			(state: State) => this.socket && this.socket.sockets.emit(socketEvent.globalStateChange, state)
 		);
 	}
 

--- a/backend/status/events.ts
+++ b/backend/status/events.ts
@@ -6,6 +6,7 @@ class StatusEvents extends EventEmitter {
 		patchStatus: 'status-patch',
 		deleteStatus: 'status-delete',
 		statusStateChange: 'status-state-change',
+		globalStateChange: 'global-state-change',
 		deleteAllStatuses: 'status-delete-all',
 	};
 }

--- a/backend/status/helper.ts
+++ b/backend/status/helper.ts
@@ -40,6 +40,22 @@ export const getStuckStatuses = (statuses: Status[]): Status[] =>
 		return false;
 	});
 
+export const getGlobalState = (statuses: Status[]): State => {
+	if (statuses.find((status) => status.state === 'warning')) {
+		return 'warning';
+	}
+
+	if (statuses.find((status) => status.state === 'error')) {
+		return 'error';
+	}
+
+	if (statuses.find((status) => status.state === 'success')) {
+		return 'success';
+	}
+
+	return 'info';
+};
+
 export const processStatusChanges = (status: Status): Status => {
 	const processes = status.processes
 		// Sort processes by creation time

--- a/backend/status/manager.ts
+++ b/backend/status/manager.ts
@@ -2,7 +2,7 @@ import StorageManager from 'backend/storage/manager';
 import Status from 'types/status';
 
 import StatusEvents from './events';
-import { fixStuckStatus, getExpiredStatuses, getStuckStatuses, processStatusChanges } from './helper';
+import { fixStuckStatus, getExpiredStatuses, getGlobalState, getStuckStatuses, processStatusChanges } from './helper';
 
 class StatusManager {
 	statuses: Status[] = [];
@@ -80,6 +80,8 @@ class StatusManager {
 		}
 
 		this.statuses = statuses;
+
+		StatusEvents.emit(StatusEvents.event.globalStateChange, getGlobalState(statuses));
 
 		// TODO: fix dependency, storage manager should listen instead
 		// beware of the race condition that events are emit before the statuses are set on the manager

--- a/types/cimonitor.ts
+++ b/types/cimonitor.ts
@@ -27,6 +27,7 @@ export const socketEvent = {
 	patchStatus: 'status-patch',
 	deleteStatus: 'status-delete',
 	statusStateChange: 'status-state-change',
+	globalStateChange: 'global-state-change',
 	requestAllStatuses: 'status-request',
 };
 


### PR DESCRIPTION
# What

Add global state change event to the socket events

## Why

[eXistenZNL/HomeAssistant-CIMonitor](https://github.com/eXistenZNL/HomeAssistant-CIMonitor) would like the keep the CIMonitor status equal to the global state. So the Home Assistant sensor remains colored dangerously when a pipeline was failing without it being resolved.
