### PR TITLE
Fix GitLab status overrides and keep cleanest title

### DIFF
--- a/backend/parser/gitlab/build.ts
+++ b/backend/parser/gitlab/build.ts
@@ -69,12 +69,14 @@ class GitLabBuildParser {
 			}
 		}
 
-		status.username = build.user.name || build.user.username;
-		status.userUrl = build.commit.author_url;
-		status.userImage = build.user.avatar_url;
-		status.sourceUrl = build.repository.homepage;
-
-		return status;
+		return {
+			...status,
+			project: build.project_name,
+			username: build.user.name || build.user.username,
+			userUrl: build.commit.author_url,
+			userImage: build.user.avatar_url,
+			sourceUrl: build.repository.homepage,
+		};
 	}
 
 	patchProcess(process: Process, build: GitLabBuild): Process {

--- a/backend/parser/gitlab/deployment.ts
+++ b/backend/parser/gitlab/deployment.ts
@@ -10,12 +10,15 @@ class GitLabDeploymentParser {
 		if (!status) {
 			status = {
 				id,
-				project: `${deployment.project.namespace} / ${deployment.project.name}`,
+				project: deployment.project.path_with_namespace,
 				state: 'info',
 				source: 'gitlab',
 				time: new Date().toUTCString(),
 				processes: [],
 				branch: deployment.ref,
+				username: deployment.user.name || deployment.user.username,
+				userImage: deployment.user.avatar_url,
+				userUrl: deployment.user_url,
 			};
 
 			if (deployment.ref) {
@@ -30,9 +33,6 @@ class GitLabDeploymentParser {
 		return {
 			...status,
 			projectImage: deployment.project.avatar_url,
-			username: deployment.user.name || deployment.user.username,
-			userImage: deployment.user.avatar_url,
-			userUrl: deployment.user_url,
 			sourceUrl: deployment.project.git_http_url,
 			url: deployment.environment_external_url,
 			time: new Date().toUTCString(),

--- a/backend/parser/gitlab/index.ts
+++ b/backend/parser/gitlab/index.ts
@@ -25,7 +25,8 @@ class GitLabParser {
 	parseBuild(build: GitLabBuild): Status {
 		console.log('[parser/gitlab] Parsing build...');
 
-		const id = this.getInternalId(build.project.id, build.repository.name, build.ref, build.tag);
+		const projectId = build.project?.id || build.project_id;
+		const id = this.getInternalId(projectId, build.repository.name, build.ref, build.tag);
 
 		return GitLabBuildParser.parse(id, build);
 	}

--- a/backend/parser/gitlab/index.ts
+++ b/backend/parser/gitlab/index.ts
@@ -25,7 +25,7 @@ class GitLabParser {
 	parseBuild(build: GitLabBuild): Status {
 		console.log('[parser/gitlab] Parsing build...');
 
-		const id = this.getInternalId(build.project_id, build.repository.name, build.ref, build.tag);
+		const id = this.getInternalId(build.project.id, build.repository.name, build.ref, build.tag);
 
 		return GitLabBuildParser.parse(id, build);
 	}

--- a/backend/parser/gitlab/merge-request.ts
+++ b/backend/parser/gitlab/merge-request.ts
@@ -9,11 +9,13 @@ class GitLabMergeRequestParser {
 		if (!status) {
 			status = {
 				id,
-				project: `${mergeRequest.project.namespace} / ${mergeRequest.project.name}`,
+				project: mergeRequest.project.path_with_namespace,
 				state: 'info',
 				source: 'gitlab',
 				time: new Date().toUTCString(),
 				processes: [],
+				username: mergeRequest.user.name || mergeRequest.user.username,
+				userImage: mergeRequest.user.avatar_url,
 				branch: mergeRequest.object_attributes.source_branch,
 			};
 
@@ -25,8 +27,6 @@ class GitLabMergeRequestParser {
 		return {
 			...status,
 			projectImage: mergeRequest.project.avatar_url,
-			username: mergeRequest.user.name || mergeRequest.user.username,
-			userImage: mergeRequest.user.avatar_url,
 			sourceUrl: mergeRequest.project.git_http_url,
 			mergeTitle: mergeRequest.object_attributes.title,
 			mergeUrl: mergeRequest.object_attributes.url,

--- a/backend/parser/gitlab/pipeline.ts
+++ b/backend/parser/gitlab/pipeline.ts
@@ -49,7 +49,7 @@ class GitLabPipelineParser {
 		if (!status) {
 			status = {
 				id,
-				project: `${pipeline.project.namespace} / ${pipeline.project.name}`,
+				project: pipeline.project.path_with_namespace,
 				state: 'info',
 				source: 'gitlab',
 				time: new Date().toUTCString(),
@@ -65,12 +65,13 @@ class GitLabPipelineParser {
 			}
 		}
 
-		status.username = pipeline.user.name || pipeline.user.username;
-		status.userImage = pipeline.user.avatar_url;
-		status.projectImage = pipeline.project.avatar_url;
-		status.sourceUrl = pipeline.project.git_http_url;
-
-		return status;
+		return {
+			...status,
+			username: pipeline.user.name || pipeline.user.username,
+			userImage: pipeline.user.avatar_url,
+			projectImage: pipeline.project.avatar_url,
+			sourceUrl: pipeline.project.git_http_url,
+		};
 	}
 
 	patchProcess(process: Process, pipeline: GitLabPipeline): Process {

--- a/types/gitlab.ts
+++ b/types/gitlab.ts
@@ -130,6 +130,7 @@ export type GitLabBuild = {
 	project_id: number;
 	project_name: string;
 	user: GitLabUser;
+	project: GitLabProject;
 	commit: {
 		id: number;
 		sha: string;

--- a/types/gitlab.ts
+++ b/types/gitlab.ts
@@ -130,7 +130,7 @@ export type GitLabBuild = {
 	project_id: number;
 	project_name: string;
 	user: GitLabUser;
-	project: GitLabProject;
+	project?: GitLabProject;
 	commit: {
 		id: number;
 		sha: string;


### PR DESCRIPTION
# What

- Users are no longer overwritten when there was no pipeline or test
- The clean project title from a `build` is now leading

## Why

Sometimes status changes would appear to not be correct, this was due to mixing of the different web hooks. Now a more sane decision is made on what status elements should always be overriden in a web hook
